### PR TITLE
003 link plot points api

### DIFF
--- a/api/plotpoints/src/main/java/org/kaccag/plotpoint/PlotPointEntity.java
+++ b/api/plotpoints/src/main/java/org/kaccag/plotpoint/PlotPointEntity.java
@@ -20,6 +20,8 @@ public class PlotPointEntity {
 
     private String description;
 
+    private UUID precedingPlotPointId;
+
     // Empty constructor for spring to do its magic
     PlotPointEntity() {
     }
@@ -67,11 +69,19 @@ public class PlotPointEntity {
         this.description = description;
     }
 
+    public UUID getPrecedingPlotPointId() {
+        return precedingPlotPointId;
+    }
+
+    public void setPrecedingPlotPointId(UUID precedingPlotPointId) {
+        this.precedingPlotPointId = precedingPlotPointId;
+    }
+
     @Override
     public String toString() {
         return String.format(
-                "Plotpoint[id=%s, user=%s, summary=%s, description=%s]",
-                id, user, summary, description
+                "Plotpoint[id=%s, user=%s, summary=%s, description=%s, prePlotpointId=%s]",
+                id, user, summary, description, precedingPlotPointId
         );
     }
 }

--- a/api/plotpoints/src/main/java/org/kaccag/plotpoint/PlotPointService.java
+++ b/api/plotpoints/src/main/java/org/kaccag/plotpoint/PlotPointService.java
@@ -34,6 +34,17 @@ public class PlotPointService {
                 plotPoint.getDescription()
         );
         checkForExistingPlotPoint(generatedId);
+        if (plotPoint.getPrecedingPlotPointId() != null) {
+            try {
+                PlotPointEntity preceding = getById(plotPoint.getPrecedingPlotPointId());
+                if (preceding.getUser() != generatedId.getUser())
+                    throw new IllegalArgumentException(
+                            "Provided preceding plot point is not by the same user");
+                generatedId.setPrecedingPlotPointId(preceding.getId());
+            } catch (ResourceNotFoundException e) {
+                throw new ResourceNotFoundException("Provided preceding plot point does not exist", e);
+            }
+        }
 
         repo.insert(generatedId);
         LOGGER.info("Successfully created new plot point");

--- a/api/plotpoints/src/main/java/org/kaccag/plotpoint/PlotPointService.java
+++ b/api/plotpoints/src/main/java/org/kaccag/plotpoint/PlotPointService.java
@@ -59,7 +59,7 @@ public class PlotPointService {
 
         List<PlotPointEntity> usersPP = getByUser(deleted.getUser());
         for (PlotPointEntity entry : usersPP) {
-            if (entry.getPrecedingPlotPointId() != null && entry.getPrecedingPlotPointId() == id) {
+            if (entry.getPrecedingPlotPointId() != null && entry.getPrecedingPlotPointId().equals(id)) {
                 PlotPointEntity ppToBeUpdated = new PlotPointEntity();
                 ppToBeUpdated.setId(entry.getId());
                 // Update to deleted preceding plot point
@@ -126,7 +126,7 @@ public class PlotPointService {
         if (passedPlotPoint.getPrecedingPlotPointId() != null) {
             try {
                 PlotPointEntity preceding = getById(passedPlotPoint.getPrecedingPlotPointId());
-                if (preceding.getUser() != endPlotPoint.getUser())
+                if (!preceding.getUser().equals(endPlotPoint.getUser()))
                     throw new IllegalArgumentException(
                             "Provided preceding plot point is not by the same user");
                 endPlotPoint.setPrecedingPlotPointId(preceding.getId());

--- a/api/plotpoints/src/main/java/org/kaccag/plotpoint/PlotPointService.java
+++ b/api/plotpoints/src/main/java/org/kaccag/plotpoint/PlotPointService.java
@@ -34,17 +34,7 @@ public class PlotPointService {
                 plotPoint.getDescription()
         );
         checkForExistingPlotPoint(generatedId);
-        if (plotPoint.getPrecedingPlotPointId() != null) {
-            try {
-                PlotPointEntity preceding = getById(plotPoint.getPrecedingPlotPointId());
-                if (preceding.getUser() != generatedId.getUser())
-                    throw new IllegalArgumentException(
-                            "Provided preceding plot point is not by the same user");
-                generatedId.setPrecedingPlotPointId(preceding.getId());
-            } catch (ResourceNotFoundException e) {
-                throw new ResourceNotFoundException("Provided preceding plot point does not exist", e);
-            }
-        }
+        validatePrecedingPlotPoint(plotPoint, generatedId);
 
         repo.insert(generatedId);
         LOGGER.info("Successfully created new plot point");
@@ -116,6 +106,20 @@ public class PlotPointService {
                     "Plot point by user %s with summary %s already exist",
                     plotPoint.getUser(), plotPoint.getSummary()));
             throw new IllegalArgumentException("Received plot point already exists");
+        }
+    }
+
+    private void validatePrecedingPlotPoint(PlotPointEntity passedPlotPoint, PlotPointEntity endPlotPoint) {
+        if (passedPlotPoint.getPrecedingPlotPointId() != null) {
+            try {
+                PlotPointEntity preceding = getById(passedPlotPoint.getPrecedingPlotPointId());
+                if (preceding.getUser() != endPlotPoint.getUser())
+                    throw new IllegalArgumentException(
+                            "Provided preceding plot point is not by the same user");
+                endPlotPoint.setPrecedingPlotPointId(preceding.getId());
+            } catch (ResourceNotFoundException e) {
+                throw new ResourceNotFoundException("Provided preceding plot point does not exist", e);
+            }
         }
     }
 

--- a/api/plotpoints/src/main/java/org/kaccag/plotpoint/PlotPointService.java
+++ b/api/plotpoints/src/main/java/org/kaccag/plotpoint/PlotPointService.java
@@ -148,17 +148,27 @@ public class PlotPointService {
      * This excludes user, as this should not change, and
      * id as it was used to find the non template instance.
      *
-     * @param foundPlotPoint
+     * @param currentPlotPoint
      * @param template
      */
-    private void updateFoundWithValues(PlotPointEntity foundPlotPoint, PlotPointEntity template) {
+    private void updateFoundWithValues(PlotPointEntity currentPlotPoint, PlotPointEntity template) {
         // TODO whitelist, not blacklist. Return a new Object
         // For each parameter, if it is asking to be changed, change it.
         if (template.getSummary() != null && !template.getSummary().equals(""))
-            foundPlotPoint.setSummary(template.getSummary());
-        if (template.getDescription() != null && !template.getDescription().equals(""))
-            foundPlotPoint.setDescription(template.getDescription());
-        if (template.getPrecedingPlotPointId() != null)
-            foundPlotPoint.setPrecedingPlotPointId(template.getPrecedingPlotPointId());
+            currentPlotPoint.setSummary(template.getSummary());
+        if (currentPlotPoint.getDescription() != template.getDescription()) {
+            if (template.getDescription() != null) {
+                if (template.getDescription().equals(""))
+                    template.setDescription(null);
+                currentPlotPoint.setDescription(template.getDescription());
+            }
+        }
+        if (currentPlotPoint.getPrecedingPlotPointId() != null) {
+            if (!currentPlotPoint.getPrecedingPlotPointId().equals(template.getPrecedingPlotPointId())) {
+                if (template.getPrecedingPlotPointId() == null)
+                    currentPlotPoint.setPrecedingPlotPointId(null);
+                validatePrecedingPlotPoint(template, currentPlotPoint);
+            }
+        }
     }
 }

--- a/api/plotpoints/src/test/java/org/kaccag/plotpoint/PlotPointServiceTest.java
+++ b/api/plotpoints/src/test/java/org/kaccag/plotpoint/PlotPointServiceTest.java
@@ -29,8 +29,6 @@ public class PlotPointServiceTest {
         plotPointWithPreceding.setId(SECOND_VALID_ID);
         plotPointWithPreceding.setPrecedingPlotPointId(EXISTING_ID);
 
-        System.out.printf("********\nPlot point to emulate\n%s\n", plotPointWithPreceding.toString());
-
         Optional<PlotPointEntity> foundPlotPoint = Optional.of(plotPoint);
         Optional<PlotPointEntity> missingPlotPoint = Optional.empty();
 
@@ -198,7 +196,6 @@ public class PlotPointServiceTest {
 
         PlotPointEntity returned = service.insert(plotPointWithPrePlotPoint);
 
-        System.out.printf("********\nPlot point sent\n%s\nPlot point returned\n%s\n", plotPointWithPrePlotPoint.toString(), returned.toString());
         Assert.assertEquals(EXISTING_ID, returned.getPrecedingPlotPointId());
     }
 

--- a/api/plotpoints/src/test/java/org/kaccag/plotpoint/PlotPointServiceTest.java
+++ b/api/plotpoints/src/test/java/org/kaccag/plotpoint/PlotPointServiceTest.java
@@ -200,6 +200,36 @@ public class PlotPointServiceTest {
     }
 
     @Test
+    public void insertWithInvalidPrePlotPointId() {
+        PlotPointEntity plotPoint = new PlotPointEntity(
+                "user1", "summary2", "description1"
+        );
+        plotPoint.setPrecedingPlotPointId(MISSING_ID);
+
+        try {
+            service.insert(plotPoint);
+            Assert.fail("Preceding plot point of missing id should throw exception");
+        } catch (ResourceNotFoundException e) {
+            // Expected error thrown
+        }
+    }
+
+    @Test
+    public void insertWithDifferentPrePlotPointUser() {
+        PlotPointEntity plotPoint = new PlotPointEntity(
+                "invalidUser", "summary2", "description1"
+        );
+        plotPoint.setPrecedingPlotPointId(EXISTING_ID);
+
+        try {
+            service.insert(plotPoint);
+            Assert.fail("Preceding plot point by different user should throw exception");
+        } catch (IllegalArgumentException e) {
+            // Expected error thrown
+        }
+    }
+
+    @Test
     public void updateWithNullTemplate() {
         try {
             service.update(null);


### PR DESCRIPTION
Added ability for plot point to have a preceding plot point.
Added validation that a preceding plot point exists, is owned by the user etc.
Ability to update and delete and preceding plot point objects are handled.